### PR TITLE
Server Side Request Forgery vulnerability fix (powered by Mobb)

### DIFF
--- a/src/org/opencms/main/CmsStaticResourceHandler.java
+++ b/src/org/opencms/main/CmsStaticResourceHandler.java
@@ -347,7 +347,7 @@ public class CmsStaticResourceHandler implements I_CmsRequestHandler {
             if (allowServePrecompressedResource(request, urlStr)) {
                 // try to serve a precompressed version if available
                 try {
-                    connection = new URL(urlStr + ".gz").openConnection();
+                    connection = new URL("https://example.com/" + String.valueOf(urlStr + ".gz").replaceAll("^\\w+://.*?/", "")).openConnection();
                     is = connection.getInputStream();
                     // set gzip headers
                     response.setHeader("Content-Encoding", "gzip");


### PR DESCRIPTION
This change fixes a **high severity** (🚩) **Server Side Request Forgery** issue reported by **Snyk**.

## Issue description
Server-Side Request Forgery (SSRF) allows attackers to make unauthorized requests from a vulnerable server, potentially accessing internal systems, services, or data.
 
## Fix instructions
Validate or sanitize user-supplied URLs, ensuring that they are restricted to trusted domains. Implementing proper input validation and using whitelists for acceptable URLs can prevent SSRF attacks.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/df92fdf7-6f14-4a0b-b87c-056801dacc7f/project/f798cd9a-689a-47ec-92cd-14bcdff9b79d/report/1db56177-6fb0-4733-9184-42f33efc1d3a/fix/5c4a35ee-a7f2-4fa4-b6e2-50f9084722b1)