### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/src/org/opencms/staticexport/A_CmsStaticExportHandler.java
+++ b/src/org/opencms/staticexport/A_CmsStaticExportHandler.java
@@ -60,7 +60,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
-
+import java.io.IOException;
+import java.net.URI;
 /**
  * Abstract base implementation for the <code>{@link I_CmsStaticExportHandler}</code> interface.<p>
  *
@@ -379,6 +380,7 @@ public abstract class A_CmsStaticExportHandler implements I_CmsStaticExportHandl
                                     + rfsName.substring(
                                         OpenCms.getStaticExportManager().getRfsPrefix(vfsName).length()));
                             try {
+                                ensurePathIsRelative(exportFolderName);
                                 File exportFolder = new File(exportFolderName);
                                 // check if export folder exists, if so delete it
                                 if (exportFolder.exists() && exportFolder.canWrite()) {
@@ -476,6 +478,37 @@ public abstract class A_CmsStaticExportHandler implements I_CmsStaticExportHandl
                     Messages.LOG_SCRUB_EXPORT_FINISH_RESOURCE_2,
                     res.getRootPath(),
                     (System.currentTimeMillis() - timer) + ""));
+        }
+    }
+
+    private static void ensurePathIsRelative(String path) {
+        ensurePathIsRelative(new File(path));
+    }
+
+
+    private static void ensurePathIsRelative(URI uri) {
+        ensurePathIsRelative(new File(uri));
+    }
+
+
+    private static void ensurePathIsRelative(File file) {
+        // Based on https://stackoverflow.com/questions/2375903/whats-the-best-way-to-defend-against-a-path-traversal-attack/34658355#34658355
+        String canonicalPath;
+        String absolutePath;
+    
+        if (file.isAbsolute()) {
+            throw new RuntimeException("Potential directory traversal attempt - absolute path not allowed");
+        }
+    
+        try {
+            canonicalPath = file.getCanonicalPath();
+            absolutePath = file.getAbsolutePath();
+        } catch (IOException e) {
+            throw new RuntimeException("Potential directory traversal attempt", e);
+        }
+    
+        if (!canonicalPath.startsWith(absolutePath) || !canonicalPath.equals(absolutePath)) {
+            throw new RuntimeException("Potential directory traversal attempt");
         }
     }
 


### PR DESCRIPTION
This change fixes a **high severity** (🚩) **Path Traversal** issue reported by **Snyk**.

## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/df92fdf7-6f14-4a0b-b87c-056801dacc7f/project/f798cd9a-689a-47ec-92cd-14bcdff9b79d/report/1db56177-6fb0-4733-9184-42f33efc1d3a/fix/9fb88f4c-7bf7-42f2-87c5-974192e70e72)