### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/src/org/opencms/cache/CmsVfsNameBasedDiskCache.java
+++ b/src/org/opencms/cache/CmsVfsNameBasedDiskCache.java
@@ -37,6 +37,7 @@ import java.io.UnsupportedEncodingException;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.logging.Log;
+import java.net.URI;
 
 /**
  * Implements a name based RFS file based disk cache, that handles parameter based versions of VFS files.<p>
@@ -84,6 +85,7 @@ public class CmsVfsNameBasedDiskCache {
     public byte[] getCacheContent(String rfsName) {
 
         try {
+            ensurePathIsRelative(rfsName);
             File f = new File(rfsName);
             if (f.exists()) {
                 long age = f.lastModified();
@@ -98,6 +100,37 @@ public class CmsVfsNameBasedDiskCache {
             LOG.debug("Unable to read file " + rfsName, e);
         }
         return null;
+    }
+
+    private static void ensurePathIsRelative(String path) {
+        ensurePathIsRelative(new File(path));
+    }
+
+
+    private static void ensurePathIsRelative(URI uri) {
+        ensurePathIsRelative(new File(uri));
+    }
+
+
+    private static void ensurePathIsRelative(File file) {
+        // Based on https://stackoverflow.com/questions/2375903/whats-the-best-way-to-defend-against-a-path-traversal-attack/34658355#34658355
+        String canonicalPath;
+        String absolutePath;
+    
+        if (file.isAbsolute()) {
+            throw new RuntimeException("Potential directory traversal attempt - absolute path not allowed");
+        }
+    
+        try {
+            canonicalPath = file.getCanonicalPath();
+            absolutePath = file.getAbsolutePath();
+        } catch (IOException e) {
+            throw new RuntimeException("Potential directory traversal attempt", e);
+        }
+    
+        if (!canonicalPath.startsWith(absolutePath) || !canonicalPath.equals(absolutePath)) {
+            throw new RuntimeException("Potential directory traversal attempt");
+        }
     }
 
     /**


### PR DESCRIPTION
This change fixes a **high severity** (🚩) **Path Traversal** issue reported by **Snyk**.

## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/df92fdf7-6f14-4a0b-b87c-056801dacc7f/project/f798cd9a-689a-47ec-92cd-14bcdff9b79d/report/1db56177-6fb0-4733-9184-42f33efc1d3a/fix/943b15f2-8e95-495e-b1c8-864e698e574d)