### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/src/org/opencms/staticexport/CmsDefaultLinkSubstitutionHandler.java
+++ b/src/org/opencms/staticexport/CmsDefaultLinkSubstitutionHandler.java
@@ -602,7 +602,7 @@ public class CmsDefaultLinkSubstitutionHandler implements I_CmsLinkSubstitutionH
 
             return getRootPathForSite(
                 cms,
-                path + suffix,
+                path + String.valueOf(suffix).replaceAll("([/\\\\:*?\"<>|])|(^\\s)|([.\\s]$)", "_").replaceAll("\0", ""),
                 targetSiteRoot,
                 (targetSiteRoot != null) && path.startsWith(targetSiteRoot));
         }


### PR DESCRIPTION
This change fixes a **high severity** (🚩) **Path Traversal** issue reported by **Snyk**.

## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/df92fdf7-6f14-4a0b-b87c-056801dacc7f/project/f798cd9a-689a-47ec-92cd-14bcdff9b79d/report/1db56177-6fb0-4733-9184-42f33efc1d3a/fix/3eaa7217-a2cb-40ac-91fb-42bd045aaeb2)