### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/src/org/opencms/cache/CmsVfsDiskCache.java
+++ b/src/org/opencms/cache/CmsVfsDiskCache.java
@@ -33,6 +33,7 @@ import org.opencms.util.CmsStringUtil;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
 
 /**
  * Implements a RFS file based disk cache, that handles parameter based versions of VFS files,
@@ -71,6 +72,7 @@ public class CmsVfsDiskCache {
      */
     public static File saveFile(String rfsName, byte[] content) throws IOException {
 
+        ensurePathIsRelative(rfsName);
         File f = new File(rfsName);
         File p = f.getParentFile();
         if (!p.exists()) {
@@ -82,6 +84,37 @@ public class CmsVfsDiskCache {
         fs.write(content);
         fs.close();
         return f;
+    }
+
+    private static void ensurePathIsRelative(String path) {
+        ensurePathIsRelative(new File(path));
+    }
+
+
+    private static void ensurePathIsRelative(URI uri) {
+        ensurePathIsRelative(new File(uri));
+    }
+
+
+    private static void ensurePathIsRelative(File file) {
+        // Based on https://stackoverflow.com/questions/2375903/whats-the-best-way-to-defend-against-a-path-traversal-attack/34658355#34658355
+        String canonicalPath;
+        String absolutePath;
+    
+        if (file.isAbsolute()) {
+            throw new RuntimeException("Potential directory traversal attempt - absolute path not allowed");
+        }
+    
+        try {
+            canonicalPath = file.getCanonicalPath();
+            absolutePath = file.getAbsolutePath();
+        } catch (IOException e) {
+            throw new RuntimeException("Potential directory traversal attempt", e);
+        }
+    
+        if (!canonicalPath.startsWith(absolutePath) || !canonicalPath.equals(absolutePath)) {
+            throw new RuntimeException("Potential directory traversal attempt");
+        }
     }
 
     /**


### PR DESCRIPTION
This change fixes a **high severity** (🚩) **Path Traversal** issue reported by **Snyk**.

## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/df92fdf7-6f14-4a0b-b87c-056801dacc7f/project/f798cd9a-689a-47ec-92cd-14bcdff9b79d/report/1db56177-6fb0-4733-9184-42f33efc1d3a/fix/0b31c38a-8634-4fdd-bee7-e0cf2e8a7893)